### PR TITLE
Add real eeg data and corrected hover amplitude

### DIFF
--- a/workflows/eeg-viewer/dev/230731_real-data_corrected-hover-amplitude.ipynb
+++ b/workflows/eeg-viewer/dev/230731_real-data_corrected-hover-amplitude.ipynb
@@ -75,16 +75,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Synthetic data pipeline\n",
+    "## Generate simulated data\n",
     "\n",
     "The `generate_eeg_powerlaw` function synthesizes EEG data as high-pass filtered pink noise power law time series by default. The function returns a 2D numpy array of synthetic EEG data (in microvolts) shaped as (number of channels, total samples), a 1D time array (in seconds), and a list of channel names. Parameters such as the high-pass filter factor (in Hz) and an amplitude scaling factor allow customization of the generated data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Generate synthetic data"
    ]
   },
   {
@@ -107,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Visualize synthetic data"
+    "## Visualize synthetic EEG data with minimap"
    ]
   },
   {
@@ -200,7 +193,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Real data pipeline"
+    "## Load and plot real data"
    ]
   },
   {
@@ -210,13 +203,6 @@
    "outputs": [],
    "source": [
     "import mne"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Download, read real dataset"
    ]
   },
   {
@@ -239,7 +225,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw = mne.io.read_raw_edf(local_file_path, preload=True)\n",
+    "raw = mne.io.read_raw_edf(local_file_path, preload=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "raw.info"
    ]
   },
@@ -253,13 +247,6 @@
    "source": [
     "# preview the channel names, types, signal ranges, and uncompressed size\n",
     "raw.describe()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Clean channel names, set sensor positions, and reference data"
    ]
   },
   {
@@ -317,13 +304,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Gather the data for plotting into simple arrays"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -335,13 +315,6 @@
     "# get the EEG data (for this data set, all channels are EEG anyways)\n",
     "eeg_indices = mne.pick_types(raw.info, eeg=True)\n",
     "data = raw.get_data(picks=eeg_indices, units={\"eeg\":\"uV\"})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Visualize real data"
    ]
   },
   {
@@ -410,6 +383,144 @@
     "eeg_app = pn.Column(pn.Row(eeg_viewer, min_height=500), minimap).servable(target='main')\n",
     "eeg_app"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scratch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This dataset is ~20 MB\n",
+    "url = \"https://github.com/mne-tools/mne-testing-data/raw/master/EDF/test_edf_stim_resamp.edf\"\n",
+    "local_data_path = \"../../data/\"\n",
+    "\n",
+    "# Will not download if already present at local_data_path\n",
+    "local_file_path = download_file(url, local_data_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw = mne.io.read_raw_edf(local_file_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time = raw.times\n",
+    "channels = raw.ch_names\n",
+    "\n",
+    "eeg_indices = mne.pick_types(raw.info, eeg=True)\n",
+    "\n",
+    "eeg_indices\n",
+    "\n",
+    "data = raw.get_data(picks=eeg_indices)\n",
+    "\n",
+    "data.shape\n",
+    "\n",
+    "t_crop_start = 0\n",
+    "t_crop_end = 60000\n",
+    "ch_crop_start = 50\n",
+    "ch_crop_end = 60\n",
+    "data = data[ch_crop_start:ch_crop_end,t_crop_start:t_crop_end]\n",
+    "time = time[t_crop_start:t_crop_end]\n",
+    "channels = channels[ch_crop_start:ch_crop_end]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Set vertical spacing for EEG traces to avoid visual overlap\n",
+    "# spacing = 1.2\n",
+    "# offset = np.max(np.abs(data)) * spacing\n",
+    "\n",
+    "# spacing = 2.0  # adjust this value to increase or decrease the spacing between traces\n",
+    "# offset = np.std(data) * spacing\n",
+    "\n",
+    "# # Create a hv.Curve element per channel\n",
+    "# channel_curves = []\n",
+    "# max_data = data.max()\n",
+    "# for i, channel_data in enumerate(data):\n",
+    "#     offset_data = channel_data + (i * offset)\n",
+    "#     max_data = max(offset_data.max(), max_data)  # update max\n",
+    "#     channel_curves.append(\n",
+    "#         hv.Curve((time, offset_data), \"Time\").opts(\n",
+    "#             color=\"black\", line_width=1,\n",
+    "#             tools=[\"hover\", 'xwheel_zoom'], shared_axes=False))\n",
+    "\n",
+    "# # Create mapping from yaxis location to ytick for each channel\n",
+    "# yticks = [(i * offset, ich) for i, ich in enumerate(channels)]\n",
+    "\n",
+    "# # Create an overlay of curves\n",
+    "# eeg_viewer = hv.Overlay(channel_curves, kdims=\"Channel\").opts(\n",
+    "#     padding=0, xlabel=\"Time (s)\", ylabel=\"Channel\", yticks=yticks, show_legend=False, aspect=1.5, responsive=True,\n",
+    "#     shared_axes=False, backend_opts={\n",
+    "#         \"x_range.bounds\": (time.min(), time.max()),\n",
+    "#         \"y_range.bounds\": (data.min(), max_data)})\n",
+    "\n",
+    "# # Get the y positions of the yticks to use as yaxis of minimap image\n",
+    "# y_positions, _ = zip(*yticks)\n",
+    "\n",
+    "# # Compute z-scores across time for each channel\n",
+    "# z_data = zscore(data, axis=1)\n",
+    "\n",
+    "# # Generate the zscored image for the minimap using the y tick positions from the eeg_viewer\n",
+    "# minimap = hv.Image((time, y_positions, z_data), [\"Time (s)\", \"Channel\"], \"Amplitude (uV)\")\n",
+    "\n",
+    "# # Style the minimap \n",
+    "# minimap = minimap.opts(\n",
+    "#     cmap=\"RdBu_r\", colorbar=False, xlabel='', alpha=.5, yticks=[yticks[0], yticks[-1]],\n",
+    "#     height=100, responsive=True, default_tools=[''], shared_axes=False, clim=(-z_data.std()*2.5, z_data.std()*2.5))\n",
+    "\n",
+    "# # Create RangeToolLink between the minimap and the main EEG viewer \n",
+    "# max_ch_disp = 10  # max channels to initially display\n",
+    "# if len(channels) < max_ch_disp:\n",
+    "#     max_ch_disp = len(channels)\n",
+    "# max_y_disp = np.max(data[max_ch_disp-1,:] + ((max_ch_disp-1) * offset))\n",
+    "\n",
+    "# max_t_disp = 5\n",
+    "# time_s = len(time)/raw.info['sfreq']\n",
+    "# if time_s < max_t_disp:\n",
+    "#     max_t_disp = time_s\n",
+    "    \n",
+    "# RangeToolLink(minimap, list(eeg_viewer.values())[0], axes=[\"x\", \"y\"],\n",
+    "#               boundsx=(None, max_t_disp),\n",
+    "#               boundsy=(None, max_y_disp))\n",
+    "\n",
+    "# # Display vertically\n",
+    "# eeg_app = pn.Column(pn.Row(eeg_viewer, min_height=500), minimap).servable(target='main')\n",
+    "# eeg_app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
- [ ] Add a real data pipeline to the eeg viewer workflow
- [ ] correct the displayed hover tooltip amplitude by using a custom hover tooltip and reference the offset-unadjusted data

![image](https://github.com/holoviz-topics/neuro/assets/6613202/1e51d487-5904-470a-97a7-d21070e42156)
