### PR TITLE
Add benchmark for interaction (zoom)

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -41,7 +41,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["multiple_benchmarks_per_scenario"],
+    "branches": ["main"],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -41,7 +41,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["benchmark_framework"],
+    "branches": ["multiple_benchmarks_per_scenario"],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL

--- a/benchmarks/benchmarks/base.py
+++ b/benchmarks/benchmarks/base.py
@@ -43,6 +43,13 @@ class Base:
                     raise RuntimeError(f"Mismatch in render count: {count} != {expected_render_count}")
                 self._render_counts[figure_id] = count
 
+    def click_button_and_wait_for_render(self, button_name: str, figure_id: str) -> None:
+        button = self.page.get_by_role("button", name=button_name)
+        start_render_count = self.render_count(figure_id)
+        button.click()
+        while self.render_count(figure_id) == start_render_count:
+            self.page.wait_for_timeout(1)
+
     def current_figure_id(self) -> str:
         """Return the id of the currently displayed Bokeh figure.
 

--- a/benchmarks/benchmarks/base.py
+++ b/benchmarks/benchmarks/base.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
 
 
 class Base:
+    # Force a single benchmark timing for each setup-teardown call, and no warmup required.
+    number = 1
+    warmup_time = 0
+
     def __init__(self, catch_console: bool = True):
         self._catch_console = catch_console
         self._port = 5006
@@ -82,6 +86,7 @@ class Base:
             # Wait a few milliseconds for emitted console messages to be handled before closing
             # browser. May need to increase this if Playwright complains that browser is closed.
             self.page.wait_for_timeout(10)
+            self._render_counts.clear()
 
         self._browser.close()
         self._server.stop()

--- a/benchmarks/benchmarks/base.py
+++ b/benchmarks/benchmarks/base.py
@@ -17,24 +17,43 @@ class Base:
     def __init__(self, catch_console: bool = True):
         self._catch_console = catch_console
         self._port = 5006
-        self.render_count = -1
-        self._figure_id = None  # Unique ID of the figure to grab the console messages of.
+
+        # Dictionary of Bokeh figure ID to current render count.  Updated in _console_callback.
+        # Do not read it directly, use render_count() function instead.
+        self._render_counts: dict[str, int] = {}
 
     def _console_callback(self, msg: ConsoleMessage) -> None:
-        if self._figure_id is None or len(msg.args) != 4:
+        if len(msg.args) != 4:
             return
 
         msg, figure_id, count, start_or_end = [arg.json_value() for arg in msg.args]
 
-        if msg == "PlotView._actual_paint" and figure_id == self._figure_id:
+        if msg == "PlotView._actual_paint":
             if start_or_end == "start":
                 # TODO: need to handle start of render if want to time a single render.
                 pass
             elif start_or_end == "end":
-                self.render_count += 1
+                expected_render_count = self.render_count(figure_id) + 1
                 count = int(count)
-                if count != self.render_count:
-                    raise RuntimeError(f"Mismatch in render count: {count} != {self.render_count}")
+                if count != expected_render_count:
+                    raise RuntimeError(f"Mismatch in render count: {count} != {expected_render_count}")
+                self._render_counts[figure_id] = count
+
+    def current_figure_id(self) -> str:
+        """Return the id of the currently displayed Bokeh figure.
+
+        Assumes the current bokeh document contains a single figure.
+        """
+        sessions = self._server.get_sessions()
+        if len(sessions) != 1:
+            raise RuntimeError(f"Expected a single session but have {len(sessions)}")
+        doc = sessions[0].document
+        # This raises an error if more or less than one figure in the Bokeh document.
+        figure = doc.select_one(dict(type=Plot))
+        return figure.id
+
+    def render_count(self, figure_id) -> int:
+        return self._render_counts.get(figure_id, -1)
 
     def playwright_setup(self, bokeh_doc: Callable[[Document], None]) -> None:
         # Playwright context manager needs to span multiple functions,
@@ -50,22 +69,16 @@ class Base:
         self.page = self._browser.new_page()
         self.page.goto(f"http://localhost:{self._port}/")
 
-        # Assume Bokeh document contains a single figure, and obtain its ID.
-        sessions = self._server.get_sessions()
-        if len(sessions) != 1:
-            raise RuntimeError(f"Expected a single session but have {len(sessions)}")
-        doc = sessions[0].document
-        # This raises an error if there is more than one figure in the Bokeh document.
-        self._figure_id = doc.select_one(dict(type=Plot)).id
-
         if self._catch_console:
             self.page.on("console", self._console_callback)
 
+        # Wait for first render regardless of figure_id.
+        while len(self._render_counts) == 0:
+            self.page.wait_for_timeout(1)
+
     def playwright_teardown(self):
-        self._figure_id = None
         if self._catch_console:
             self.page.remove_listener("console", self._console_callback)
-            self.render_count = -1
             # Wait a few milliseconds for emitted console messages to be handled before closing
             # browser. May need to increase this if Playwright complains that browser is closed.
             self.page.wait_for_timeout(10)

--- a/benchmarks/benchmarks/base.py
+++ b/benchmarks/benchmarks/base.py
@@ -59,7 +59,7 @@ class Base:
         if len(sessions) != 1:
             raise RuntimeError(f"Expected a single session but have {len(sessions)}")
         doc = sessions[0].document
-        # This raises an error if more or less than one figure in the Bokeh document.
+        # This raises an error if more or fewer than one figure in the Bokeh document.
         figure = doc.select_one(dict(type=Plot))
         return figure.id
 

--- a/benchmarks/benchmarks/bokeh_example.py
+++ b/benchmarks/benchmarks/bokeh_example.py
@@ -19,9 +19,21 @@ def bkapp(doc: Document, n: int, output_backend: str):
     p = figure(width=600, height=400, output_backend=output_backend)
     p.line(source=cds, x="x", y="y")
 
-    # Prepare data but do not send it to browser yet.
+# Prepare data but do not send it to browser yet.
     x = np.arange(n)
     y = np.random.default_rng(8343).uniform(size=n)
+
+    # Set initial range to 1/10th of the data's total x and y range.
+    x_start = x[0]
+    x_end = x_start + (x[-1] - x_start) / 10
+    y_start = min(y)
+    y_end = y_start + (max(y) - y_start) / 10
+
+    # Update the figure's x and y range.
+    p.x_range.start = x_start
+    p.x_range.end = x_end
+    p.y_range.start = y_start
+    p.y_range.end = y_end
 
     def run_callback(event):
         # Latency benchmark times the sending and rendering of this data.
@@ -32,7 +44,10 @@ def bkapp(doc: Document, n: int, output_backend: str):
 
     def zoom_callback(event):
         # Zoom benchmark times the render caused by this zoom.
-        p.x_range.start = 500
+        p.x_range.start = x[0]
+        p.x_range.end = x[-1]
+        p.y_range.start = min(y)
+        p.y_range.end = max(y)
 
     zoom_button = Button(label="zoom")
     zoom_button.on_click(zoom_callback)

--- a/benchmarks/benchmarks/bokeh_example.py
+++ b/benchmarks/benchmarks/bokeh_example.py
@@ -1,6 +1,3 @@
-
-
-
 from __future__ import annotations
 
 from functools import partial
@@ -43,7 +40,7 @@ def bkapp(doc: Document, n: int, output_backend: str):
     doc.add_root(column(p, row(run_button, zoom_button)))
 
 
-class TimeseriesBase(Base):
+class BokehExampleBase(Base):
     params: tuple[list[int], list[str]] = (
         [1_000, 10_000, 100_000, 1_000_000],
         ["canvas", "webgl"],
@@ -63,7 +60,7 @@ class TimeseriesBase(Base):
         self.playwright_teardown()
 
 
-class TimeseriesLatency(TimeseriesBase):
+class BokehExampleLatency(BokehExampleBase):
     """Example benchmark using Bokeh only, measuring the latency which is the
     time taken to transfer data to the browser and render it. The browser and
     Bokeh server are already running before the benchmark starts.
@@ -72,7 +69,7 @@ class TimeseriesLatency(TimeseriesBase):
         self.click_button_and_wait_for_render("run", self.figure_id)
 
 
-class TimeseriesZoom(TimeseriesBase):
+class BokehExampleZoom(BokehExampleBase):
     """Example benchmark using Bokeh only, measuring the time taken for an
     interactive render which is achieved here using by zooming the figure.
     """

--- a/benchmarks/benchmarks/timeseries.py
+++ b/benchmarks/benchmarks/timeseries.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from bokeh.models import Button, ColumnDataSource
-from bokeh.plotting import column, figure
+from bokeh.plotting import column, figure, row
 import numpy as np
 
 from .base import Base
@@ -23,17 +23,24 @@ def bkapp(doc: Document, n: int, output_backend: str):
     x = np.arange(n)
     y = np.random.default_rng(8343).uniform(size=n)
 
-    def python_callback(event):
-        # Benchmark times the sending and rendering of this data.
+    def run_callback(event):
+        # Latency benchmark times the sending and rendering of this data.
         cds.data = dict(x=x, y=y)
 
-    button = Button(label="run")
-    button.on_click(python_callback)
+    run_button = Button(label="run")
+    run_button.on_click(run_callback)
 
-    doc.add_root(column(p, button))
+    def zoom_callback(event):
+        # Zoom benchmarks times the render caused by this zoom.
+        p.x_range.start = 500
+
+    zoom_button = Button(label="zoom")
+    zoom_button.on_click(zoom_callback)
+
+    doc.add_root(column(p, row(run_button, zoom_button)))
 
 
-class Timeseries(Base):
+class TimeseriesLatency(Base):
     params: tuple[list[int], list[str]] = (
         [1_000, 10_000, 100_000, 1_000_000, 10_000_000],
         ["canvas", "webgl"],
@@ -52,8 +59,42 @@ class Timeseries(Base):
         self.figure_id = None
         self.playwright_teardown()
 
-    def time_values(self, n: int, output_backend: str) -> None:
+    def time_latency(self, n: int, output_backend: str) -> None:
         button = self.page.get_by_role("button", name="run")
+        start_render_count = self.render_count(self.figure_id)
+        button.click()
+        while self.render_count(self.figure_id) == start_render_count:
+            self.page.wait_for_timeout(1)
+
+
+class TimeseriesZoom(Base):
+    params: tuple[list[int], list[str]] = (
+        [1_000, 10_000, 100_000, 1_000_000, 10_000_000],
+        ["canvas", "webgl"],
+    )
+    param_names: tuple[str] = ("n", "output_backend")
+
+    def setup(self, n: int, output_backend: str) -> None:
+        bkapp_n = partial(bkapp, n=n, output_backend=output_backend)
+        self.playwright_setup(bkapp_n)
+
+        # There is only a single Bokeh figure in each benchmark so store its ID here rather than
+        # in the benchmark itself.
+        self.figure_id = self.current_figure_id()
+
+        # Render initial data set.
+        button = self.page.get_by_role("button", name="run")
+        start_render_count = self.render_count(self.figure_id)
+        button.click()
+        while self.render_count(self.figure_id) == start_render_count:
+            self.page.wait_for_timeout(1)
+
+    def teardown(self, n: int, output_backend: str) -> None:
+        self.figure_id = None
+        self.playwright_teardown()
+
+    def time_zoom(self, n: int, output_backend: str) -> None:
+        button = self.page.get_by_role("button", name="zoom")
         start_render_count = self.render_count(self.figure_id)
         button.click()
         while self.render_count(self.figure_id) == start_render_count:

--- a/benchmarks/benchmarks/timeseries.py
+++ b/benchmarks/benchmarks/timeseries.py
@@ -44,12 +44,17 @@ class Timeseries(Base):
         bkapp_n = partial(bkapp, n=n, output_backend=output_backend)
         self.playwright_setup(bkapp_n)
 
+        # There is only a single Bokeh figure in each benchmark so store its ID here rather than
+        # in the benchmark itself.
+        self.figure_id = self.current_figure_id()
+
     def teardown(self, n: int, output_backend: str) -> None:
+        self.figure_id = None
         self.playwright_teardown()
 
     def time_values(self, n: int, output_backend: str) -> None:
         button = self.page.get_by_role("button", name="run")
-        start_render_count = self.render_count
+        start_render_count = self.render_count(self.figure_id)
         button.click()
-        while self.render_count == start_render_count:
+        while self.render_count(self.figure_id) == start_render_count:
             self.page.wait_for_timeout(1)


### PR DESCRIPTION
This adds a benchmark for zooming an existing Bokeh figure, so records the time taken for re-rendering the figure (and any recalculation prior to that required for the re-render). It is achieved by creating a button whose callback zooms the figure so the Playwright functionality is to locate the button and click it in the same way as already performed for the latency benchmark. All of the important work occurs in JavaScript in the browser (and possibly GPU), except for some constant-ish overhead of sending the zoom request from the Python side and waiting for the render completion message to arrive on the Python side.

This is part of issue #66.

Summary of changes:

1. There is now support for multiple Bokeh figures per benchmark. This isn't actually used yet but is a better approach that will be needed in future.
2. `Base` benchmark sets the `number` and `warmup_time` of benchmark runs. This is really important here as the default `asv` behaviour assumes that the results of the `setup` stage are not affected by the actual benchmark runs whereas here that is not the case.
3. Renaming the benchmarks from `Timeseries` to `BokehExample`.
4. Some refactoring, pushing functionality down into the `Base` class so that the actual benchmark classes are as simple as possible.
5. I have removed the `n = 10_000_000` runs as this sometimes gives problems with timeouts that I have yet to solve.

On my M1 mac (no dedicated GPU) I obtain the following:
```bash
$ asv run -e
· Creating environments
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] · For hvneuro commit 0388952c <main>:
[  0.00%] ·· Benchmarking virtualenv-py3.11-playwright
[ 25.00%] ··· Running (bokeh_example.BokehExampleLatency.time_latency--).
[ 50.00%] ··· Running (bokeh_example.BokehExampleZoom.time_zoom--).
[ 75.00%] ··· bokeh_example.BokehExampleLatency.time_latency                                                                                                          ok
[ 75.00%] ··· ========= ============ ============
              --              output_backend     
              --------- -------------------------
                  n        canvas       webgl    
              ========= ============ ============
                 1000     84.7±5ms     90.4±5ms  
                10000     103±8ms      111±7ms   
                100000    238±4ms      240±4ms   
               1000000   1.71±0.01s   1.69±0.01s 
              ========= ============ ============

[100.00%] ··· bokeh_example.BokehExampleZoom.time_zoom                                                                                                                ok
[100.00%] ··· ========= ========== ============
              --             output_backend    
              --------- -----------------------
                  n       canvas      webgl    
              ========= ========== ============
                 1000    29.0±2ms    37.5±3ms  
                10000    30.5±1ms   33.0±0.7ms 
                100000   32.0±2ms    40.2±3ms  
               1000000   220±8ms     162±9ms   
              ========= ========== ============
```