### PR TITLE
Add Panel and HoloViews benchmark

### DIFF
--- a/benchmarks/benchmarks/base.py
+++ b/benchmarks/benchmarks/base.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 
 class Base:
-    # Force a single benchmark timing for each setup-teardown call, and no warmup required.
     number = 1
     warmup_time = 0
 

--- a/benchmarks/benchmarks/panel_holoviews_example.py
+++ b/benchmarks/benchmarks/panel_holoviews_example.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING
+
+import holoviews as hv
+import numpy as np
+import panel as pn
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from bokeh.document import Document
+
+
+def pnapp(doc: Document, n: int, output_backend: str):
+    hv.renderer('bokeh').webgl = (output_backend == "webgl")
+    x = np.linspace(0, 1, n)
+    y = np.random.default_rng(8343).uniform(size=n)
+
+    def run_callback(click):
+        return hv.Curve((x, y) if click else [])
+
+    button = pn.widgets.Button(name='run')
+    app = pn.Row(button, hv.DynamicMap(pn.bind(run_callback, button)))
+
+    doc.add_root(app.get_root())
+
+
+class PanelHoloviewsExample(Base):
+    params: tuple[list[int], list[str]] = (
+        [1_000, 10_000, 100_000, 1_000_000],
+        ["canvas", "webgl"],
+    )
+    param_names: tuple[str] = ("n", "output_backend")
+
+    def setup(self, n: int, output_backend: str) -> None:
+        pnapp_n = partial(pnapp, n=n, output_backend=output_backend)
+        self.playwright_setup(pnapp_n)
+
+        # There is only a single Bokeh figure in each benchmark so store its ID here rather than
+        # in the benchmark itself.
+        self.figure_id = self.current_figure_id()
+
+    def teardown(self, n: int, output_backend: str) -> None:
+        self.figure_id = None
+        self.playwright_teardown()
+
+    def time_latency(self, n: int, output_backend: str) -> None:
+        self.click_button_and_wait_for_render("run", self.figure_id)

--- a/benchmarks/benchmarks/panel_holoviews_example.py
+++ b/benchmarks/benchmarks/panel_holoviews_example.py
@@ -28,6 +28,10 @@ def pnapp(doc: Document, n: int, output_backend: str):
 
 
 class PanelHoloviewsExample(Base):
+    # Force a single benchmark timing for each setup-teardown call.
+    repeat = 1
+    rounds = 5
+
     params: tuple[list[int], list[str]] = (
         [1_000, 10_000, 100_000, 1_000_000],
         ["canvas", "webgl"],


### PR DESCRIPTION
This builds on top of #73 and will need to be rebased against `main` after that PR is merged.

It adds a benchmark of a Panel and HoloViews example that was supplied by @droumis and @philippjfr. It runs fine provided each benchmark is only run once (using the `-q` flag), i.e. `asv run -e -b Panel -q`.

Running each benchmark multiple times in the normal manner (`asv run -e -b Panel`) gives the following error:
```
RuntimeError: Models must be owned by only a single document, ImportedStyleSheet(id='p1005', ...) is already in a doc
```
which I think implies that the Bokeh/Panel/Tornado servers are not restarting as I intended between multiple repeats of the same benchmark.

I will continue with this next week.