### PR TITLE
Add holoviz zoom benchmark

### DIFF
--- a/benchmarks/benchmarks/base.py
+++ b/benchmarks/benchmarks/base.py
@@ -92,7 +92,7 @@ class Base:
         self._server = Server({'/': bokeh_doc}, port=self._port)
         self._server.start()
 
-        self._browser = playwright.chromium.launch(headless=False)
+        self._browser = playwright.chromium.launch(headless=True)
 
         self.page = self._browser.new_page()
         self.page.goto(f"http://localhost:{self._port}/")

--- a/benchmarks/benchmarks/bokeh_example.py
+++ b/benchmarks/benchmarks/bokeh_example.py
@@ -73,7 +73,7 @@ class BokehExampleBase(Base):
     rounds = 5
 
     params: tuple[list[int], list[str]] = (
-        [1_000],#, 10_000, 100_000, 1_000_000],
+        [1_000, 10_000, 100_000, 1_000_000],
         ["canvas", "webgl"],
     )
     param_names: tuple[str] = ("n", "output_backend")

--- a/benchmarks/benchmarks/bokeh_example.py
+++ b/benchmarks/benchmarks/bokeh_example.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
 
+if __name__ == "__main__":
+    import bokeh
+    bokeh.settings.settings.log_level = "trace"
+
+    import sys
+    from pathlib import Path
+
+    script_directory = Path(__file__).parent
+    sys.path.append(str(script_directory))
+
+    from base import Base
+
+else:
+    from .base import Base
+
 from functools import partial
 from typing import TYPE_CHECKING
 
 from bokeh.models import Button, ColumnDataSource
 from bokeh.plotting import column, figure, row
 import numpy as np
-
-from .base import Base
 
 if TYPE_CHECKING:
     from bokeh.document import Document
@@ -56,8 +69,11 @@ def bkapp(doc: Document, n: int, output_backend: str):
 
 
 class BokehExampleBase(Base):
+    repeat = 1  # Force a single benchmark timing for each setup-teardown call
+    rounds = 5
+
     params: tuple[list[int], list[str]] = (
-        [1_000, 10_000, 100_000, 1_000_000],
+        [1_000],#, 10_000, 100_000, 1_000_000],
         ["canvas", "webgl"],
     )
     param_names: tuple[str] = ("n", "output_backend")
@@ -69,6 +85,7 @@ class BokehExampleBase(Base):
         # There is only a single Bokeh figure in each benchmark so store its ID here rather than
         # in the benchmark itself.
         self.figure_id = self.current_figure_id()
+        self.page.wait_for_timeout(1) # warmup
 
     def teardown(self, n: int, output_backend: str) -> None:
         self.figure_id = None
@@ -83,7 +100,6 @@ class BokehExampleLatency(BokehExampleBase):
     def time_latency(self, n: int, output_backend: str) -> None:
         self.click_button_and_wait_for_render("run", self.figure_id)
 
-
 class BokehExampleZoom(BokehExampleBase):
     """Example benchmark using Bokeh only, measuring the time taken for an
     interactive render which is achieved here using by zooming the figure.
@@ -96,3 +112,19 @@ class BokehExampleZoom(BokehExampleBase):
 
     def time_zoom(self, n: int, output_backend: str) -> None:
         self.click_button_and_wait_for_render("zoom", self.figure_id)
+
+
+if __name__ == "__main__":
+
+    n = 1000
+    backend = "canvas"
+
+    init_latency = BokehExampleLatency()
+    init_latency.setup(n, backend)
+    init_latency.time_latency(n, backend)
+    init_latency.teardown(n, backend)
+
+    zoom_latency = BokehExampleZoom()
+    zoom_latency.setup(n, backend)
+    zoom_latency.time_zoom(n, backend)
+    zoom_latency.teardown(n, backend)

--- a/benchmarks/benchmarks/panel_holoviews_example.py
+++ b/benchmarks/benchmarks/panel_holoviews_example.py
@@ -12,28 +12,45 @@ from .base import Base
 if TYPE_CHECKING:
     from bokeh.document import Document
 
-
 def pnapp(doc: Document, n: int, output_backend: str):
     hv.renderer('bokeh').webgl = (output_backend == "webgl")
     x = np.linspace(0, 1, n)
     y = np.random.default_rng(8343).uniform(size=n)
 
-    def run_callback(click):
-        return hv.Curve((x, y) if click else [])
+    # Get ranges to set initial viewport to 1/10th of the data's range
+    x_start = x[0]
+    x_end = x_start + (x[-1] - x_start) / 10
+    maxy = max(y)
+    y_start = min(y)
+    y_end = y_start + (maxy - y_start) / 10
 
-    button = pn.widgets.Button(name='run')
-    app = pn.Row(button, hv.DynamicMap(pn.bind(run_callback, button)))
+    def run_zoom_callback(run, zoom):
+        if not zoom:
+            # start at 1/10th of the range
+            return hv.Curve((x, y) if run else []).opts(
+                xlim=(x_start, x_end), ylim=(y_start, y_end),
+                framewise=True)
+        
+        return hv.Curve((x, y)).opts( # zoom out to full data range
+            xlim=(x_start, x[-1]), ylim=(y_start, maxy), framewise=True)
+
+    run_button = pn.widgets.Button(name='run') # always clicked first
+    zoom_button = pn.widgets.Button(name='zoom')
+
+    dynmap = hv.DynamicMap(pn.bind(run_zoom_callback,
+                                   run=run_button,
+                                   zoom=zoom_button))
+
+    app = pn.Column(dynmap, pn.Row(run_button, zoom_button))
 
     doc.add_root(app.get_root())
 
-
-class PanelHoloviewsExample(Base):
-    # Force a single benchmark timing for each setup-teardown call.
-    repeat = 1
+class PanelHoloviewsExampleBase(Base):
+    repeat = 1 # Force a single benchmark timing for each setup-teardown call.
     rounds = 5
 
     params: tuple[list[int], list[str]] = (
-        [1_000, 10_000, 100_000, 1_000_000],
+        [1_000],#, 10_000, 100_000, 1_000_000],
         ["canvas", "webgl"],
     )
     param_names: tuple[str] = ("n", "output_backend")
@@ -45,10 +62,29 @@ class PanelHoloviewsExample(Base):
         # There is only a single Bokeh figure in each benchmark so store its ID here rather than
         # in the benchmark itself.
         self.figure_id = self.current_figure_id()
+        self.page.wait_for_timeout(10) # warmup
 
     def teardown(self, n: int, output_backend: str) -> None:
         self.figure_id = None
         self.playwright_teardown()
 
+class PanelHoloviewsExampleLatency(PanelHoloviewsExampleBase):
+    """Example benchmark using Panel and HoloViews, measuring the latency which is the
+    time taken to transfer data to the browser and render it. The browser and
+    Bokeh server are already running before the benchmark starts.
+    """
     def time_latency(self, n: int, output_backend: str) -> None:
         self.click_button_and_wait_for_render("run", self.figure_id)
+
+class PanelHoloviewsExampleZoom(PanelHoloviewsExampleBase):
+    """Example benchmark using Panel and HoloViews, measuring the time taken for an
+    interactive render which is achieved here using by zooming the figure.
+    """
+    def setup(self, n: int, output_backend: str) -> None:
+        super().setup(n, output_backend)
+
+        # Render initial data set.
+        self.click_button_and_wait_for_render("run", self.figure_id)
+
+    def time_zoom(self, n: int, output_backend: str) -> None:
+        self.click_button_and_wait_for_render("zoom", self.figure_id)

--- a/benchmarks/benchmarks/panel_holoviews_example.py
+++ b/benchmarks/benchmarks/panel_holoviews_example.py
@@ -50,7 +50,7 @@ class PanelHoloviewsExampleBase(Base):
     rounds = 5
 
     params: tuple[list[int], list[str]] = (
-        [1_000],#, 10_000, 100_000, 1_000_000],
+        [1_000, 10_000, 100_000, 1_000_000],
         ["canvas", "webgl"],
     )
     param_names: tuple[str] = ("n", "output_backend")


### PR DESCRIPTION
This PR adds a zoom interaction benchmark to the Panel/HoloViews example.

Quick test: `asv run -e -b Panel -q`
```
[ 10.00%] ··· panel_holoviews_example.PanelHoloviewsExampleLatency.time_latency                                       ok
[ 10.00%] ··· ====== ========== =========
              --        output_backend
              ------ --------------------
                n      canvas     webgl
              ====== ========== =========
               1000   83.9±0ms   134±0ms
              ====== ========== =========

[ 20.00%] ··· panel_holoviews_example.PanelHoloviewsExampleZoom.time_zoom                                             ok
[ 20.00%] ··· ====== ========== ==========
              --         output_backend
              ------ ---------------------
                n      canvas     webgl
              ====== ========== ==========
               1000   48.5±0ms   55.9±0ms
              ====== ========== ==========
```